### PR TITLE
Clean up iRODSSession in BaseRuleManager instead of RuleManager

### DIFF
--- a/irodsrulewrapper/rule.py
+++ b/irodsrulewrapper/rule.py
@@ -20,13 +20,6 @@ class RuleManager(
     def __init__(self, client_user=None, config=None, admin_mode=False):
         BaseRuleManager.__init__(self, client_user, config, admin_mode)
 
-    def __del__(self):
-        # __del__ is a destructor method which is called as soon as all references of the object are deleted.
-        # i.e when an object is garbage collected.
-        # Session cleanup is not called after each rule execution anymore.
-        # So it needs to happen here.
-        self.session.cleanup()
-
     def check_irods_connection(self):
         """
         Check if an iRODS connection can be established

--- a/irodsrulewrapper/utils.py
+++ b/irodsrulewrapper/utils.py
@@ -88,6 +88,14 @@ class BaseRuleManager:
         else:
             self.init_with_variable_config(client_user, config, admin_mode)
 
+    def __del__(self):
+        # __del__() is a finalizer that is called when the object is garbage
+        # collected. And this happens *after* all the references to the object
+        # have been deleted. This is what CPython does, however it is not
+        # guranteed behavior by Python. Ideally we do the cleanup() after using
+        # this object to execute a rule/s. Perhaps with a try/finally.
+        self.session.cleanup()
+
     def init_with_environ_conf(self, client_user, admin_mode):
         if admin_mode:
             self.session = iRODSSession(


### PR DESCRIPTION
We've seen SSL connection errors probably due to connections being left
open or not closing properly.

We are able to reproduce the error by `./rit.sh up -d mdr` and then
visiting the projects overview listing on the browser. This will load
the projects overview view. This view, aside from instantiating
RuleManager, makes use of a dto (project_overview.py). And this one
instantiates UserRuleManager.

UserRuleManager inherits directly from BaseRuleManager. So,
RuleManager's __del__() with its session.cleanup() never gets called.
Therefore we move it to BaseRuleManager.

[DHDO-171]